### PR TITLE
Add get_mongodb_client method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,18 @@
+0.12.0 (2015-04-01)
+-------------------
+- New Features:
+
+  - Method `get_mongodb_client` to get a MongoDB connection client.
+
+- Bugfixes:
+
+  - None
+
+- Incompatible changes:
+
+  - `Okapi.__init__` has changed to have a new mandatory `db` parameter.
+   Parameters `mongodb_uri` and `connect_timeout_ms` have been removed.
+
 0.11.0 (2014-12-29)
 -------------------
 - New Features:

--- a/okapi/__init__.py
+++ b/okapi/__init__.py
@@ -6,4 +6,4 @@
 #
 # Author: Gobind Ball
 
-__version__ = '0.11.0'
+__version__ = '0.12.0'

--- a/okapi/api.py
+++ b/okapi/api.py
@@ -31,8 +31,9 @@ class Api(object):
         """Initialization of class api.
 
         __init__ requires the following parameters:
-        db --  For this value, get the mongo client from the get_mongodb_client
-        method. Then set the database name on it.
+        db --  Mongo database object. Use the get_mongodb_client method to get a
+        mongo client object. Then set the database name on it to create a
+        database object.
         project_name -- name of the mongodb collection
         requests_lib -- library which should be used to make requests
         """


### PR DESCRIPTION
Update __init__ to have an additional param db.
For this param, get the value returned from get_mongodb_client
 and set the database on it.
Remove the mongodb_uri and connect_timeout_ms params from __init__.

This code does not change the way okapi works. 

The mongo connection is being done is a separate method so that the caller can create the connection only once and then set the database value on it. This database object can then be passed to the __init__ method of Okapi.

PTAL @garciaae @lorenzogil 