### PR TITLE
Fix setup description and add a long_description args

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,13 @@
+Unreleased (no-date-yet)
+-------------------
+- New Features:
+
+  - None
+
+- Bugfixes:
+
+  - Change setup() call in `setup.py` to improve package page on PyPI.
+
 0.12.0 (2015-04-01)
 -------------------
 - New Features:

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,11 @@ setup(
     version=__version__,
     author='RedBeacon (Gobind Ball)',
     author_email='support@redbeacon.com',
-    description=README + '\n\n' + CHANGES,
+    description='Requests wrapper to instrument HTTP calls',
+    long_description=README + '\n\n' + CHANGES,
+    url='https://github.com/redbeacon/okapi',
     packages=find_packages(),
-    data_files=[('config',['setup.cfg'])],
+    data_files=[('config', ['setup.cfg'])],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
@@ -32,7 +34,7 @@ setup(
         'Programming Language :: Python',
     ],
     zip_safe=False,
-    install_requires = [
+    install_requires=[
         'pymongo',
         'requests',
     ],


### PR DESCRIPTION
The way `setup()` is called, with a multi-line `description`, it renders the [package page over PyPI](https://pypi.python.org/pypi/okapi) *broken*. It also messes with `pip search foo` output.

If you'd like other description than that, just tell me and I'll update this PR.

Thanks!